### PR TITLE
Force valid value

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -10,7 +10,7 @@ const argv = process.argv.slice(2);
 helpers(argv);
 /* istanbul ignore next */
 const command = {
-	amount: argv[0] || 1, /* istanbul ignore next */
+	amount: parseFloat(argv[0]) || 1, /* istanbul ignore next */
 	from: argv[1] || config.get('defaultFrom', 'USD'),
 	to: (argv.length > 2) ? process.argv.slice(4) : config.get('defaultTo', ['USD', 'EUR', 'GBP', 'PLN'])
 };

--- a/test/test.js
+++ b/test/test.js
@@ -31,6 +31,11 @@ test('Test Conversion API (default currencies)', async t => {
 	t.regex(ret.stdout, /10/);
 });
 
+test('Test Conversion API with invalid value', async t => {
+	const ret = await execa.shell('node ./bin/index.js EXT');
+	t.regex(ret.stdout, /Conversion of PLN 1/);
+});
+
 test('Test Conversion API (1 currency)', async t => {
 	const ret = await execa.shell('node ./bin/index.js 10 usd pln');
 	t.regex(ret.stderr, /Polish Zloty/);


### PR DESCRIPTION
# Scenario
Run the command with an invalid amount

```bash
$ cash e

✔ NaN (USD) United States Dollar
✔ NaN (EUR) Euro
✔ NaN (CHF) Swiss Franc
```

# Solution
Force a number if the first element is not a number 

```bash
$ node bin/index.js e

✔ 0.266 (USD) United States Dollar
✔ 0.232 (EUR) Euro
✔ 0.264 (CHF) Swiss Franc
```


Is not a big deal, but the output is better than a `NaN`