### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
 node_js:
 - "node"
+- "10"
+- "8"
+- "6"
 after_success: npm run coverage


### PR DESCRIPTION
Current LTS are 6, 8 and 10 and we should test there too to catch any issues and check if Node.js 6 users can still use this library.