### PR TITLE
Snapcraft

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: cash
+base: core18
+version: git
+summary: Convert Currency Rates using your terminal!
+description: |
+  Convert Currency Rates using your terminal!
+
+grade: stable
+confinement: strict
+
+parts:
+  cash:
+    plugin: nodejs
+    source: .
+
+apps:
+  cash:
+    command: cash
+    plugs: [network]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,8 @@ version: git
 summary: Convert Currency Rates using your terminal!
 description: |
   Convert Currency Rates using your terminal!
-
+  
+  Get your API key at https://fixer.io/quickstart
 grade: stable
 confinement: strict
 


### PR DESCRIPTION
Hey Antoni. cash is handy, but I couldn't find it published for end users anywhere. I work on Snapcraft, so I went ahead and created a snap of it. If you build this locally and push to the Snap Store, millions of Linux users can [browse](https://snapcraft.io/store) their way to it. You can even get [Node from NodeSource](https://snapcraft.io/node) this way.

To build:
`snap install snapcraft` from Ubuntu, or [install Multipass](https://github.com/CanonicalLtd/multipass/releases) on MacOS then `brew install snapcraft`.
Run `snapcraft`

To publish, [create an account](https://snapcraft.io/account), then:
```
snapcraft login
snapcraft register cash
snapcraft push --release=stable *.snap
```